### PR TITLE
Specify CUDA flavor as devel to include nvcc at runtime

### DIFF
--- a/runway.yml
+++ b/runway.yml
@@ -1,6 +1,7 @@
 entrypoint: python runway_model.py
 python: 3.6
 cuda: 10.0
+cuda_flavor: devel
 spec:
   gpu: True
   cpu: False


### PR DESCRIPTION
A few weeks ago we added the ability to specify the CUDA flavor of the base Docker image with the `cuda_flavor `property in the `runway.yml` file. It accepts the following values: `base`, `runtime` (default), `devel`. 

This repo requires NVCC to be installed, which used to be included in the docker base image we use by default, but we've sense moved to using `runtime` instead. This update should fix future builds or folks from this repo when used with Runway.
